### PR TITLE
add trailing slash to currentUserUrl

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,9 +17,9 @@ export function initLoginButton(
 ) {
   const container = document.getElementById(containerId)
   const parsedBaseUrl = new URL(baseUrl)
-  const apiUrl = `${parsedBaseUrl.origin}/api/v0/users/me/?format=json`
+  const currentUserUrl = `${parsedBaseUrl.origin}/api/v0/users/me/?format=json`
   const loginUrl = `${parsedBaseUrl.origin}/login/ol-oidc/`
-  fetch(apiUrl, {
+  fetch(currentUserUrl, {
     method: "GET",
     credentials: "include",
     mode: "cors",

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ export function initLoginButton(
 ) {
   const container = document.getElementById(containerId)
   const parsedBaseUrl = new URL(baseUrl)
-  const apiUrl = `${parsedBaseUrl.origin}/api/v0/users/me?format=json`
+  const apiUrl = `${parsedBaseUrl.origin}/api/v0/users/me/?format=json`
   const loginUrl = `${parsedBaseUrl.origin}/login/ol-oidc/`
   fetch(apiUrl, {
     method: "GET",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/mit-open-login-button/issues/4

### Description (What does it do?)
This PR simply adds a trailing slash to the the API URL hitting `/apiv/0/users/me` to avoid a 301 redirection. 301 redirection breaks CORS requests, so this is necessary for the API request to not trigger a CORS error.

### How can this be tested?
 - In order to test this, you will need a running instance of [`mit-open`](https://github.com/mitodl/mit-open). Follow the instructions in the `mit-open` readme for initial setup. You will need an account in your local instance for this to work. Your instance of `mit-open` should be accessible at `http://od.odl.local:8063`. You will need to set the following environment variables:
```
CORS_ALLOWED_ORIGINS=["http://ocw.odl.local:3000"]
SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS=["ocw.odl.local:3000"]
```
 - You will also need `ocw-hugo-themes` (https://github.com/mitodl/ocw-hugo-themes) set up locally, running a course using `yarn start course`. Follow the readme there for basic setup instructions and make sure you can start up a course. After you have that working, check out the `cg/add-mit-open-login-button` branch. Assuming you have cloned this repo, run `yarn add /path/to/mit-open-login-button` to add your local copy of the code for this to your locally running `ocw-hugo-themes`. This is necessary because the package is not yet published to NPM. You will also need an entry in your `hosts` file that points the `ocw.odl.local` domain to `127.0.0.1`.
 - Once you have all this running, make sure you are logged out of your local instance of `mit-open`
 - Back in your locally running OCW course site, you should see a Login button in the upper right. Click this button and log in to your locally running `mit-open`
 - After you have logged in, you will be sent to http://od.odl.local:8063
 - Go back to your locally running OCW site at http://ocw.odl.local:3000 and confirm that you see `Logged in as: username` with your username in place of `username`
 - In another tab, log out of your locally running `mit-open`
 - Verify that the login button reappears
