### PR TITLE
add the redirectUrl argument and use it in loginUrl

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ export function initLoginButton(
   const parsedBaseUrl = new URL(baseUrl)
   const currentUserUrl = `${parsedBaseUrl.origin}/api/v0/users/me/?format=json`
   const redirectUrlParam =
-    redirectUrl !== "" ? `?redirect_url=${encodeURIComponent(redirectUrl)}` : ""
+    redirectUrl !== "" ? `?next=${encodeURIComponent(redirectUrl)}` : ""
   const loginUrl = `${parsedBaseUrl.origin}/login/ol-oidc/${redirectUrlParam}`
   fetch(currentUserUrl, {
     method: "GET",

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
  * @function initLoginButton
  * @param {String} containerId The id property of the container element to place the login button / status in
  * @param {String} baseUrl The base URL of the MIT Open instance
+ * @param {String} redirectUrl The URL to redirect to after login is complete
  * @param {String} buttonText The text to show on the Login button
  * @param {String} buttonClass The CSS class(es) to assign to the button
  * @param {String} loggedInTextClass The CSS class(es) to assign to the logged-in status text
@@ -11,6 +12,7 @@
 export function initLoginButton(
   containerId,
   baseUrl,
+  redirectUrl,
   buttonText = "Login",
   buttonClass = "",
   loggedInTextClass = "",
@@ -18,7 +20,7 @@ export function initLoginButton(
   const container = document.getElementById(containerId)
   const parsedBaseUrl = new URL(baseUrl)
   const currentUserUrl = `${parsedBaseUrl.origin}/api/v0/users/me/?format=json`
-  const loginUrl = `${parsedBaseUrl.origin}/login/ol-oidc/`
+  const loginUrl = `${parsedBaseUrl.origin}/login/ol-oidc/?redirect_url=${encodeURIComponent(redirectUrl)}`
   fetch(currentUserUrl, {
     method: "GET",
     credentials: "include",

--- a/index.js
+++ b/index.js
@@ -21,10 +21,8 @@ export function initLoginButton(
   const parsedBaseUrl = new URL(baseUrl)
   const currentUserUrl = `${parsedBaseUrl.origin}/api/v0/users/me/?format=json`
   const redirectUrlParam =
-    redirectUrl !== "" ? `?redirect_url=${redirectUrl}` : ""
-  const loginUrl = `${parsedBaseUrl.origin}/login/ol-oidc/${encodeURIComponent(
-    redirectUrlParam,
-  )}`
+    redirectUrl !== "" ? `?redirect_url=${encodeURIComponent(redirectUrl)}` : ""
+  const loginUrl = `${parsedBaseUrl.origin}/login/ol-oidc/${redirectUrlParam}`
   fetch(currentUserUrl, {
     method: "GET",
     credentials: "include",

--- a/index.js
+++ b/index.js
@@ -22,7 +22,9 @@ export function initLoginButton(
   const currentUserUrl = `${parsedBaseUrl.origin}/api/v0/users/me/?format=json`
   const redirectUrlParam =
     redirectUrl !== "" ? `?redirect_url=${redirectUrl}` : ""
-  const loginUrl = `${parsedBaseUrl.origin}/login/ol-oidc/${redirectUrlParam}`
+  const loginUrl = `${parsedBaseUrl.origin}/login/ol-oidc/${encodeURIComponent(
+    redirectUrlParam,
+  )}`
   fetch(currentUserUrl, {
     method: "GET",
     credentials: "include",

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@
 export function initLoginButton(
   containerId,
   baseUrl,
-  redirectUrl,
+  redirectUrl = "",
   buttonText = "Login",
   buttonClass = "",
   loggedInTextClass = "",
@@ -20,7 +20,9 @@ export function initLoginButton(
   const container = document.getElementById(containerId)
   const parsedBaseUrl = new URL(baseUrl)
   const currentUserUrl = `${parsedBaseUrl.origin}/api/v0/users/me/?format=json`
-  const loginUrl = `${parsedBaseUrl.origin}/login/ol-oidc/?redirect_url=${encodeURIComponent(redirectUrl)}`
+  const redirectUrlParam =
+    redirectUrl !== "" ? `?redirect_url=${redirectUrl}` : ""
+  const loginUrl = `${parsedBaseUrl.origin}/login/ol-oidc/${redirectUrlParam}`
   fetch(currentUserUrl, {
     method: "GET",
     credentials: "include",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/mit-open-login-button/issues/6

### Description (What does it do?)
This PR adds a new argument to `initLoginButton`, `redirectUrl`. This string argument is simply passed through as the `redirect_url` query string parameter to the login endpoint. If the domain of the redirect URL is set in the `SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS` setting on the instance of `mit-open` that you are hitting, then you will be redirected back to that URL after logging in.

### How can this be tested?
 - You will need to make a slight alteration to the code before testing this, as at the time of writing https://github.com/mitodl/mit-open-login-button/pull/5 has not been merged and it fixes an issue with the `/users/me` endpoint:
```
Replace:
const apiUrl = `${parsedBaseUrl.origin}/api/v0/users/me?format=json`
With:
const apiUrl = `${parsedBaseUrl.origin}/api/v0/users/me/?format=json`
```
 - In order to test this, you will need a running instance of [`mit-open`](https://github.com/mitodl/mit-open). Follow the instructions in the `mit-open` readme for initial setup. You will need an account in your local instance for this to work. Your instance of `mit-open` should be accessible at `http://od.odl.local:8063`. You will need to set the following environment variables:
```
CORS_ALLOWED_ORIGINS=["http://ocw.odl.local:3000"]
SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS=["ocw.odl.local:3000"]
```
 - You will also need `ocw-hugo-themes` (https://github.com/mitodl/ocw-hugo-themes) set up locally, running a course using `yarn start course`. Follow the readme there for basic setup instructions and make sure you can start up a course. After you have that working, check out the `cg/add-mit-open-login-button` branch. Assuming you have cloned this repo, run `yarn add /path/to/mit-open-login-button` to add your local copy of the code for this to your locally running `ocw-hugo-themes`. This is necessary because the package is not yet published to NPM. You will also need an entry in your `hosts` file that points the `ocw.odl.local` domain to `127.0.0.1`.
 - Once you have all this running, make sure you are logged out of your local instance of `mit-open`
 - Back in your locally running OCW course site, you should see a Login button in the upper right. Click this button and log in to your locally running `mit-open`
 - After you have logged in, you will be sent back to http://ocw.odl.local:3000
 - Confirm that you see `Logged in as: username` with your username in place of `username`
 - In another tab, log out of your locally running `mit-open`
 - Back on the local OCW page, refresh and verify that the login button reappears
